### PR TITLE
Orthodownload

### DIFF
--- a/nls-dem-downloader.py
+++ b/nls-dem-downloader.py
@@ -111,10 +111,10 @@ def load_conf(args):
         dataset = 'hila_10m'
         search_keys = config['KM10'][args.area_key]
     else:
-        dataset = 'hila_2m'
+        dataset = 'ortokuva'
         search_keys = config['KM2'][args.area_key]
 
-    product_url = 'https://tiedostopalvelu.maanmittauslaitos.fi/tp/feed/mtp/korkeusmalli/{0}?format=image/tiff&api_key={1}'.format(
+    product_url = 'https://tiedostopalvelu.maanmittauslaitos.fi/tp/feed/mtp/orto/{0}?format=image/jp2&api_key={1}'.format(
         dataset, api_token)
 
     return search_keys, product_url, args.output_dir

--- a/nls-dem-downloader.py
+++ b/nls-dem-downloader.py
@@ -108,13 +108,16 @@ def load_conf(args):
     api_token = config['API_TOKEN']
 
     if args.km10:
-        dataset = 'hila_10m'
+        dataset = 'korkeusmalli/hila_10m'
         search_keys = config['KM10'][args.area_key]
+    elif args.orto:
+        dataset = 'orto/ortokuva'
+        search_keys = config['KM2'][args.area_key]
     else:
-        dataset = 'ortokuva'
+        dataset = 'korkeusmalli/hila_2m'
         search_keys = config['KM2'][args.area_key]
 
-    product_url = 'https://tiedostopalvelu.maanmittauslaitos.fi/tp/feed/mtp/orto/{0}?format=image/jp2&api_key={1}'.format(
+    product_url = 'https://tiedostopalvelu.maanmittauslaitos.fi/tp/feed/mtp/{0}?format=image/tiff&api_key={1}'.format(
         dataset, api_token)
 
     return search_keys, product_url, args.output_dir
@@ -136,6 +139,8 @@ def parse_args():
     parser.add_argument("-v", "--verbose", help="Write script output to stdout",
                         action="store_true")
     parser.add_argument("-km10", "--km10", help="Download KM10 tiles instead of default KM2 tiles",
+                        action="store_true")
+    parser.add_argument("-orto", "--orto", help="Download orto tiles instead of default KM2 tiles",
                         action="store_true")
 
     return parser.parse_args()


### PR DESCRIPTION
This script is also handy for downloading orthophotos (because km2 tiles match to orthotiles), so I added option for that too.

my use case would be like this:
`python nls-dem-downloader.py config.json HSL ./data -orto -v`